### PR TITLE
Added option `SNI_server_certs` in  `context.ssl`

### DIFF
--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -205,6 +205,20 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="context.ssl.sni-enabled-server-certs">
+     <term>
+      <parameter>SNI_server_certs</parameter>
+      <type>array</type>
+     </term>
+     <listitem>
+      <para>
+        Path to local certificate file on filesystem.  It must be a PEM
+        encoded file which contains your certificate and private key.
+        It can optionally contain the certificate chain of issuers.
+        e.g. <code>['host1' => '/path/host1.pem', 'host2' => '/path/host2.pem'];</code>
+      </para>
+     </listitem>
+    </varlistentry>
     <varlistentry xml:id="context.ssl.disable-compression">
      <term>
       <parameter>disable_compression</parameter>


### PR DESCRIPTION
My English is poor. This is my first time editing a php document.
The original document lack the option. After studying a lot of materials, this option `SNI_server_certs` was found.
The description of option may not be accurate, please correct it directly.